### PR TITLE
Lazy load API clients

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  // You can omit apiVersion here if you initialized Stripe without it
-  apiVersion: "2025-05-28.basil",
-});
-
 export async function POST(req: NextRequest) {
   try {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      console.error("❌ STRIPE_SECRET_KEY is not configured");
+      return NextResponse.json(
+        { error: "Stripe not configured" },
+        { status: 500 }
+      );
+    }
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: "2025-05-28.basil",
+    });
     const { priceId, email } = await req.json();
 
     if (!priceId || !email) {


### PR DESCRIPTION
## Summary
- lazy instantiate Stripe and Resend inside API routes
- return a 500 with a helpful message when missing API keys

## Testing
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68516d8f0e3c832d934a32746b44f1db