### PR TITLE
Fix auth persistence for vendor dashboard

### DIFF
--- a/app/Navbar.tsx
+++ b/app/Navbar.tsx
@@ -10,6 +10,7 @@ export default function Navbar() {
   const handleSignOut = async () => {
     const supabase = getBrowserSupabase();
     await supabase.auth.signOut();
+    await fetch("/api/auth/session", { method: "DELETE" });
     window.location.reload();
   };
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -120,6 +120,7 @@ export default function AccountPage() {
         onClick={async () => {
           const supabase = getBrowserSupabase();
           await supabase.auth.signOut();
+          await fetch("/api/auth/session", { method: "DELETE" });
           window.location.reload();
         }}
         className="rounded bg-black text-white px-6 py-2 hover:opacity-90"

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { access_token, refresh_token } = await req.json();
+  if (!access_token || !refresh_token) {
+    return NextResponse.json({ error: "Missing tokens" }, { status: 400 });
+  }
+  const res = NextResponse.json({ success: true });
+  const secure = process.env.NODE_ENV === "production";
+  res.cookies.set("sb-access-token", access_token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure,
+    path: "/",
+  });
+  res.cookies.set("sb-refresh-token", refresh_token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure,
+    path: "/",
+  });
+  return res;
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set("sb-access-token", "", { maxAge: 0, path: "/" });
+  res.cookies.set("sb-refresh-token", "", { maxAge: 0, path: "/" });
+  return res;
+}

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -30,6 +30,17 @@ export default function SignIn() {
       setLoading(false);
       return;
     }
+    if (data.session) {
+      await fetch("/api/auth/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token,
+        }),
+      });
+    }
+
     const role = data.user?.user_metadata?.role;
     // If role is missing, force a session refresh and reload
     if (!role) {

--- a/app/vendor/page.tsx
+++ b/app/vendor/page.tsx
@@ -256,6 +256,7 @@ export default function VendorDashboard() {
   const signOut = async () => {
     const supabase = getBrowserSupabase();
     await supabase.auth.signOut();
+    await fetch("/api/auth/session", { method: "DELETE" });
     router.push("/");
   };
 


### PR DESCRIPTION
## Summary
- persist auth tokens in cookies via `/api/auth/session`
- call new endpoint on sign-in
- clear cookies on sign-out

## Testing
- `node test-access-control.js`

------
https://chatgpt.com/codex/tasks/task_e_68581c031700832dbee6d4a59dd9d3f2