### PR TITLE
Fix cookie domain issue in auth session handler

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -7,25 +7,25 @@ export async function POST(req: NextRequest) {
   }
   const res = NextResponse.json({ success: true });
   const secure = process.env.NODE_ENV === "production";
-  const url = process.env.NEXT_PUBLIC_SITE_URL || req.nextUrl.origin;
-  const domain = "." + new URL(url).hostname.replace(/^www\./, "");
+  const host = req.nextUrl.hostname;
+  const domain = host === "localhost" ? undefined : "." + host.replace(/^www\./, "");
   const cookieOptions = {
     httpOnly: true,
     sameSite: "lax" as const,
     secure,
     path: "/",
-    domain,
+    ...(domain && { domain }),
   };
   res.cookies.set("sb-access-token", access_token, cookieOptions);
   res.cookies.set("sb-refresh-token", refresh_token, cookieOptions);
   return res;
 }
 
-export async function DELETE() {
+export async function DELETE(req: NextRequest) {
   const res = NextResponse.json({ success: true });
-  const url = process.env.NEXT_PUBLIC_SITE_URL || "";
-  const domain = url ? "." + new URL(url).hostname.replace(/^www\./, "") : undefined;
-  const options = { maxAge: 0, path: "/", domain } as const;
+  const host = req.nextUrl.hostname;
+  const domain = host === "localhost" ? undefined : "." + host.replace(/^www\./, "");
+  const options = { maxAge: 0, path: "/", ...(domain && { domain }) } as const;
   res.cookies.set("sb-access-token", "", options);
   res.cookies.set("sb-refresh-token", "", options);
   return res;


### PR DESCRIPTION
## Summary
- ensure auth cookies use the current request host

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685967a476b4832d98c3649e5ad9b06e