### PR TITLE
Fix missing auth cookies after email confirm

### DIFF
--- a/lib/useSupabaseUser.ts
+++ b/lib/useSupabaseUser.ts
@@ -14,9 +14,26 @@ export function useSupabaseUser() {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
       setUser(session?.user ?? null);
       setLoading(false);
+
+      if (event === "SIGNED_IN" && session) {
+        await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            access_token: session.access_token,
+            refresh_token: session.refresh_token,
+          }),
+        });
+      } else if (event === "SIGNED_OUT") {
+        await fetch("/api/auth/session", {
+          method: "DELETE",
+          credentials: "include",
+        });
+      }
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- persist auth cookies on sign in/out in `useSupabaseUser`

## Testing
- `node test-access-control.js`

------
https://chatgpt.com/codex/tasks/task_e_686006d7493c832d92de98a5d6f17781