### PR TITLE
Fix auth cookies on first visit after email confirmation

### DIFF
--- a/lib/useSupabaseUser.ts
+++ b/lib/useSupabaseUser.ts
@@ -11,12 +11,55 @@ export function useSupabaseUser() {
   useEffect(() => {
     const supabase = getBrowserSupabase();
 
+    // Immediately check for an existing session on mount
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      setUser(session?.user ?? null);
+      setLoading(false);
+
+      if (session) {
+        await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            access_token: session.access_token,
+            refresh_token: session.refresh_token,
+          }),
+        });
+      }
+    });
+
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
       setUser(session?.user ?? null);
       setLoading(false);
+
+      const sendTokens =
+        session &&
+        ["INITIAL_SESSION", "SIGNED_IN", "TOKEN_REFRESHED", "USER_UPDATED"].includes(
+          event,
+        );
+
+      if (sendTokens) {
+        await fetch("/api/auth/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            access_token: session!.access_token,
+            refresh_token: session!.refresh_token,
+          }),
+        });
+      }
+
+      if (event === "SIGNED_OUT") {
+        await fetch("/api/auth/session", {
+          method: "DELETE",
+          credentials: "include",
+        });
+      }
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- update `useSupabaseUser` to immediately sync server cookies using the current session

## Testing
- `node test-access-control.js`
- `node test-supabase.js`
- `node test-supabase-security.js`


------
https://chatgpt.com/codex/tasks/task_e_686006d7493c832d92de98a5d6f17781