### PR TITLE
Add ROOT_DOMAIN cookie domain handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ STRIPE_WEBHOOK_SECRET=
 RESEND_API_KEY=
 ### Site URL (local) ###
 NEXT_PUBLIC_SITE_URL=
+# Domain used for cookies in production
+ROOT_DOMAIN=notiontemplateshop.com
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ RESEND_API_KEY=your_resend_api_key
 
 # Application Configuration
 NEXT_PUBLIC_SITE_URL=your_site_url
+ROOT_DOMAIN=notiontemplateshop.com
 ```
 
 ### Security Notes
@@ -264,6 +265,7 @@ NEXT_PUBLIC_SITE_URL=your_site_url
 - **Supabase URL**: The `NEXT_PUBLIC_SUPABASE_URL` should be in the format `https://your-project-ref.supabase.co`
 - **Project Reference Protection**: The application now dynamically extracts the hostname from the environment variable instead of hardcoding it, preventing exposure of your project reference in the codebase
 - **Environment Variables**: Never commit `.env` files to version control. Use `.env.local` for local development and set environment variables in your deployment platform
+- **Root Domain**: Set `ROOT_DOMAIN` in `.env` to your production base domain so cookies work across subdomains
 
 ## 📁 Project Structure
 

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -8,7 +8,13 @@ export async function POST(req: NextRequest) {
   const res = NextResponse.json({ success: true });
   const secure = process.env.NODE_ENV === "production";
   const host = req.nextUrl.hostname;
-  const domain = host === "localhost" ? undefined : "." + host.replace(/^www\./, "");
+  const domain = secure
+    ? process.env.ROOT_DOMAIN
+      ? `.${process.env.ROOT_DOMAIN}`
+      : undefined
+    : host === "localhost"
+      ? undefined
+      : "." + host.replace(/^www\./, "");
   const cookieOptions = {
     httpOnly: true,
     sameSite: "lax" as const,
@@ -24,7 +30,13 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const res = NextResponse.json({ success: true });
   const host = req.nextUrl.hostname;
-  const domain = host === "localhost" ? undefined : "." + host.replace(/^www\./, "");
+  const domain = process.env.NODE_ENV === "production"
+    ? process.env.ROOT_DOMAIN
+      ? `.${process.env.ROOT_DOMAIN}`
+      : undefined
+    : host === "localhost"
+      ? undefined
+      : "." + host.replace(/^www\./, "");
   const options = { maxAge: 0, path: "/", ...(domain && { domain }) } as const;
   res.cookies.set("sb-access-token", "", options);
   res.cookies.set("sb-refresh-token", "", options);


### PR DESCRIPTION
## Summary
- add `ROOT_DOMAIN` to environment docs
- include `ROOT_DOMAIN` in `.env.example`
- set auth session cookie domain based on `ROOT_DOMAIN`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6861821027d0832d8a0a7228786fea00