### PR TITLE
Use central Supabase client in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabase } from '@/lib/supabase';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
-  
+
   // Create Supabase client for middleware
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const supabase = getSupabase();
 
   // Get the current user from the request cookies
   const authCookie = req.cookies.get('sb-access-token')?.value;


### PR DESCRIPTION
## Summary
- use the shared `getSupabase` helper in `middleware.ts`
- remove direct anon-key client creation

## Testing
- `npm test` *(fails: NEXT_PUBLIC_SUPABASE_URL environment variable is required)*
- `node test-supabase-security.js`
- `node test-access-control.js`

------
https://chatgpt.com/codex/tasks/task_e_686184c99bc4832dae16b97e82c72885