### PR TITLE
Add session cookie test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This will check:
 - ✅ Role-based navigation in navbar
 - ✅ Documentation completeness
 
+Run the session cookie test to verify authentication cookies:
+
+```bash
+node test-session-cookies.js
+```
+
+This ensures `/api/auth/session` sets `sb-access-token` and `sb-refresh-token` cookies with the proper domain.
+
 ### Manual Testing Checklist
 
 #### 1. Unauthenticated User Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.2",
+        "node-fetch": "^3.3.2",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.0",
         "typescript": "^5"
@@ -4832,6 +4833,16 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -6030,6 +6041,30 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6141,6 +6176,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -9343,6 +9391,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11534,6 +11622,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.2",
+    "node-fetch": "^3.3.2",
     "tailwindcss": "^4",
     "ts-jest": "^29.4.0",
     "typescript": "^5"

--- a/test-session-cookies.js
+++ b/test-session-cookies.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify cookies are set by /api/auth/session
+ * Run with: node test-session-cookies.js
+ */
+
+import fetch from 'node-fetch';
+
+async function testSessionCookies() {
+  console.log('🍪 Testing /api/auth/session cookie handling\n');
+
+  const tokens = {
+    access_token: 'test_access_token',
+    refresh_token: 'test_refresh_token'
+  };
+
+  try {
+    const res = await fetch('http://localhost:3000/api/auth/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(tokens),
+      redirect: 'manual'
+    });
+
+    const cookieHeader = res.headers.raw()['set-cookie'] || [];
+    const accessCookie = cookieHeader.find(c => c.startsWith('sb-access-token='));
+    const refreshCookie = cookieHeader.find(c => c.startsWith('sb-refresh-token='));
+
+    if (!accessCookie || !refreshCookie) {
+      console.error('❌ Session cookies not found');
+      process.exit(1);
+    }
+    console.log('✅ Session cookies present');
+
+    const domainMatch = /domain=([^;]+)/i.exec(accessCookie.toLowerCase());
+    const cookieDomain = domainMatch ? domainMatch[1] : undefined;
+
+    const host = 'localhost';
+    const secure = process.env.NODE_ENV === 'production';
+    const expectedDomain = secure
+      ? process.env.ROOT_DOMAIN
+        ? `.${process.env.ROOT_DOMAIN}`
+        : undefined
+      : host === 'localhost'
+        ? undefined
+        : '.' + host.replace(/^www\./, '');
+
+    if (cookieDomain === expectedDomain || (!cookieDomain && expectedDomain === undefined)) {
+      console.log(`✅ Domain matches expected (${cookieDomain ?? 'none'})`);
+    } else {
+      console.error(`❌ Domain mismatch. Expected ${expectedDomain ?? 'none'}, got ${cookieDomain ?? 'none'}`);
+      process.exit(1);
+    }
+
+    console.log('\n🎉 All cookie tests passed!');
+  } catch (err) {
+    console.error('❌ Error during test:', err.message);
+    process.exit(1);
+  }
+}
+
+await testSessionCookies();


### PR DESCRIPTION
## Summary
- add `test-session-cookies.js` script to verify `/api/auth/session` sets cookies
- document running the script in README
- install `node-fetch` for the script

## Testing
- `npm test` *(fails: NEXT_PUBLIC_SUPABASE_URL environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_686186417838832dbb110aec7e203581