### PR TITLE
Fix Supabase sign‑out

### DIFF
--- a/lib/useBrowserSupabase.ts
+++ b/lib/useBrowserSupabase.ts
@@ -1,0 +1,23 @@
+"use client";
+import { useEffect, useState } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export function useBrowserSupabase(): SupabaseClient | null {
+  const [client, setClient] = useState<SupabaseClient | null>(null);
+
+  useEffect(() => {
+    const newClient = createBrowserClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    });
+    setClient(newClient);
+  }, [document.cookie]);
+
+  return client;
+}


### PR DESCRIPTION
## Summary
- add a hook to always create a fresh browser Supabase client
- update session provider to use the new hook

## Testing
- `npm test`
- `node test-access-control.js`
- `node test-supabase-security.js`


------
https://chatgpt.com/codex/tasks/task_e_6873e6a2a048832dbf9611d326b51fbe